### PR TITLE
fix: resolve webpack on the cwd

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "webpack"
   ],
   "activationEvents": [
-    "workspaceContains:node_modules/webpack",
+    "workspaceContains:node_modules/.bin/webpack",
     "onCommand:vscode-webpack.start",
     "onCommand:vscode-webpack.trigger",
     "onCommand:vscode-webpack.stop"

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -36,7 +36,7 @@ async function startWebpack({
   configFile: string;
 }) {
   try {
-    const webpackPath = path.resolve(cwd, "node_modules", "webpack");
+    const webpackPath = require.resolve("webpack", { paths: [cwd] });
     const webpack = require(webpackPath);
 
     const config: webpack.Configuration = require(path.join(cwd, configFile));


### PR DESCRIPTION
Do not build the path to require webpack, but let node require.resolve
do that. This works as well for monorepos.